### PR TITLE
(#101) change scenario create test task

### DIFF
--- a/features/dashboard/test_tasks_management.feature
+++ b/features/dashboard/test_tasks_management.feature
@@ -39,10 +39,11 @@ Feature: test tasks management
     Given system has staff user
     When I sign in as staff
     Then I can access dashboard
+    Given system has created 'active' test task
     When I open test tasks page in dashboard
     When I click New Test task link on Test tasks page
     Then I can see 'Create Test task' button on Test task page
     When I update title with 'New title'
     When I update description
     And I click 'Create Test task' button on Test task page
-    Then I can see new test task
+    Then test task 'New title' has 'active' status

--- a/features/step_definitions/dashboard/test_tasks_steps.rb
+++ b/features/step_definitions/dashboard/test_tasks_steps.rb
@@ -43,7 +43,3 @@ end
 When('I click {string} button on Test task page') do |button_name|
   @page = @page.public_send("click_#{button_name}_button".tr(' ', '_').downcase)
 end
-
-Then('I can see new test task') do
-  expect(@page.has_text?('New test task')).to eq true
-end


### PR DESCRIPTION
In the new database, there is no role name and skill, I had to add the creation of a pre-test task