### PR TITLE
(#143) temporarily comment button waiting in profile features

### DIFF
--- a/features/step_definitions/dashboard/profile_steps.rb
+++ b/features/step_definitions/dashboard/profile_steps.rb
@@ -12,7 +12,8 @@ When('I click {string} link on profile') do |link|
 end
 
 Then('I can see {string} button on edit profile') do |button_name|
-  Watir::Wait.until { @browser.button(value: button_name).visible? }
+  # TODO: delete, if success
+  # Watir::Wait.until { @browser.button(value: button_name).visible? }
   expect(@page.public_send("#{button_name}_button?".downcase)).to eq true
 end
 


### PR DESCRIPTION
(#143) temporarily comment button waiting in profile features

I ran tests several times

![default](https://user-images.githubusercontent.com/30253042/42139545-75430132-7d98-11e8-992d-52154d968960.png)

